### PR TITLE
Update WorkZoneSandbox class to work with WZDx v3.1

### DIFF
--- a/lambda__wzdx_ingest_to_archive.py
+++ b/lambda__wzdx_ingest_to_archive.py
@@ -25,12 +25,16 @@ if None in [BUCKET, LAMBDA_TO_TRIGGER]:
 
 def lambda_handler(event=None, context=None):
     """AWS Lambda handler. """
-    wzdx_sandbox = WorkZoneRawSandbox(feed=event['feed'], bucket=BUCKET,
-                    lambda_to_trigger=LAMBDA_TO_TRIGGER,
-                    socrata_lambda_to_trigger=SOCRATA_LAMBDA_TO_TRIGGER,
-                    logger=logger)
-    wzdx_sandbox.ingest()
-
+    try:
+        wzdx_sandbox = WorkZoneRawSandbox(feed=event['feed'], bucket=BUCKET,
+                        lambda_to_trigger=LAMBDA_TO_TRIGGER,
+                        socrata_lambda_to_trigger=SOCRATA_LAMBDA_TO_TRIGGER,
+                        logger=logger)
+        wzdx_sandbox.ingest()
+    except:
+        print(traceback.format_exc())
+        print(event)
+        raise
 
 if __name__ == '__main__':
     lambda_handler()

--- a/lambda__wzdx_ingest_to_lake.py
+++ b/lambda__wzdx_ingest_to_lake.py
@@ -22,10 +22,14 @@ if None in [BUCKET]:
 
 def lambda_handler(event=None, context=None):
     """AWS Lambda handler. """
-    wzdx_sandbox = WorkZoneSandbox(feed=event['feed'], bucket=BUCKET, logger=logger)
-    datastream = wzdx_sandbox.s3helper.get_data_stream(event['bucket'], event['key'])
-    wzdx_sandbox.ingest(data=datastream.data.decode('utf-8'))
-
+    try:
+        wzdx_sandbox = WorkZoneSandbox(feed=event['feed'], bucket=BUCKET, logger=logger)
+        datastream = wzdx_sandbox.s3helper.get_data_stream(event['bucket'], event['key'])
+        wzdx_sandbox.ingest(data=datastream.data.decode('utf-8'))
+    except:
+        print(traceback.format_exc())
+        print(event)
+        raise
 
 if __name__ == '__main__':
     lambda_handler()

--- a/lambda__wzdx_ingest_to_socrata.py
+++ b/lambda__wzdx_ingest_to_socrata.py
@@ -21,7 +21,14 @@ SOCRATA_PARAMS = json.loads(os.environ.get('SOCRATA_PARAMS', ''))
 
 def lambda_handler(event=None, context=None):
     """AWS Lambda handler. """
+    try:
+        main(event, context)
+    except:
+        print(traceback.format_exc())
+        print(event)
+        raise
 
+def main(event, context):
     # load and parse data
     wzdx_sandbox = WorkZoneSandbox(feed=event['feed'], bucket=None, logger=logger)
     datastream = wzdx_sandbox.s3helper.get_data_stream(event['bucket'], event['key'])
@@ -29,10 +36,10 @@ def lambda_handler(event=None, context=None):
 
     # load and initialize data flattener based on schema version
     # flattener_class = load_flattener('wzdx/V{}'.format(event['feed']['version']))
-    if int(event['feed']['version']) == 2:
+    if event['feed']['version'][0] == '2':
         flattener_class = WzdxV2Flattener
         current_updated_time = data['road_event_feed_info']['feed_update_date'][:19]
-    elif int(event['feed']['version'][0]) == 3:
+    elif event['feed']['version'][0] == '3':
         flattener_class = WzdxV3Flattener
         current_updated_time = data['road_event_feed_info']['update_date'][:19]
     flattener = flattener_class()
@@ -59,7 +66,6 @@ def lambda_handler(event=None, context=None):
     else:
         logger.info(f'No records in feed - will not update Socrata dataset')
     
-
 
 if __name__ == '__main__':
     lambda_handler()

--- a/lambda__wzdx_ingest_to_socrata.py
+++ b/lambda__wzdx_ingest_to_socrata.py
@@ -32,7 +32,7 @@ def lambda_handler(event=None, context=None):
     if int(event['feed']['version']) == 2:
         flattener_class = WzdxV2Flattener
         current_updated_time = data['road_event_feed_info']['feed_update_date'][:19]
-    elif int(event['feed']['version']) == 3:
+    elif int(event['feed']['version'][0]) == 3:
         flattener_class = WzdxV3Flattener
         current_updated_time = data['road_event_feed_info']['update_date'][:19]
     flattener = flattener_class()

--- a/tests/test_wzdx_sandbox.py
+++ b/tests/test_wzdx_sandbox.py
@@ -5,4 +5,3 @@ import os
 class TestWZDxSandboxImports(unittest.TestCase):
     def test_imports(self):
         from wzdx_sandbox.wzdx_sandbox import ITSSandbox, WorkZoneSandbox, WorkZoneRawSandbox
-        pass

--- a/tests/test_wzdx_sandbox.py
+++ b/tests/test_wzdx_sandbox.py
@@ -1,0 +1,8 @@
+import unittest
+import os
+
+
+class TestWZDxSandboxImports(unittest.TestCase):
+    def test_imports(self):
+        from wzdx_sandbox.wzdx_sandbox import ITSSandbox, WorkZoneSandbox, WorkZoneRawSandbox
+        pass

--- a/wzdx_sandbox/wzdx_sandbox.py
+++ b/wzdx_sandbox/wzdx_sandbox.py
@@ -275,7 +275,7 @@ class WorkZoneSandbox(ITSSandbox):
             feed_version = data[header_field_name]['version']
             generate_out_rec = lambda activity: {header_field_name: data[header_field_name], activity_list_field_name: [activity], 'type': data['type']}
         else:
-            # spec version 3
+            # spec version 3, 3.1
             activity_list_field_name = 'features'
             header_field_name = 'road_event_feed_info'
             update_time_field_name = 'update_date'
@@ -288,8 +288,8 @@ class WorkZoneSandbox(ITSSandbox):
         prefix = self.prefix_template.format(**self.feed, year=YYYYMM[:4], month=YYYYMM[-2:])
         
         template = '{identifier}_{beginLocation_roadDirection}_{YYYYMM}_v{version}'
-        get_identifier = lambda feed_version, status: status['identifier'] if feed_version == '1' else status['properties']['road_event_id']
-        get_begin_road_direction = lambda feed_version, status: status['beginLocation']['roadDirection'] if feed_version == '1' else status['properties']['direction']
+        get_identifier = lambda feed_version, status: status['identifier'] if feed_version[0] == '1' else status['properties'].get('road_event_id') or status.get('id')
+        get_begin_road_direction = lambda feed_version, status: status['beginLocation']['roadDirection'] if feed_version[0] == '1' else status['properties']['direction']
         new_statuses = {
             self.generate_fp(
                 template, 


### PR DESCRIPTION
This PR does the following:
- Update WorkZoneSandbox class to work with WZDx v3.1
- Print event object when lambda functions hit errors

This PR should not be merged until https://github.com/usdot-its-jpo-data-portal/sandbox_exporter/pull/7 is merged into master branch.

Related ticket: [RDAODTD-2470](https://usdotjpoode.atlassian.net/browse/RDAODTD-2470)